### PR TITLE
Change cache-control age to sixty seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   acl: public_read
   local_dir: build/
   skip_cleanup: true
-  cache_control: public, max-age=86400 # TODO: Set multiple values
+  cache_control: public, max-age=60 # TODO: Set multiple values
   access_key_id: $AWS_KEY
   secret_access_key: $AWS_KEY_SECRET
   on: { all_branches: true }


### PR DESCRIPTION
This means the site will be refetched by the CDN caches after 60s. This isn't ideal, but until we have a site being built with hashed filenames for resources, we can't set the standard year-long cache timeouts so this will have to do.
